### PR TITLE
Rewrite iris server example

### DIFF
--- a/demo/iris-server.R
+++ b/demo/iris-server.R
@@ -7,41 +7,43 @@ library(jsonlite)
 ## reading the service definitions
 spec <- system.file('examples/iris_classifier.proto', package = 'grpc')
 
-## build model for scoring (this is to be cached)
+## build model for scoring (saved to global environment)
 library(rpart)
 names(iris) <- tolower(sub('.', '_', names(iris), fixed = TRUE))
 fit <- rpart(species ~ ., iris)
 
 ## define service definitions
 impl <- read_services(spec)
+
 impl$Classify$f <- function(request) {
 
-    flog.info('Data received for scoring: %s', toJSON(as.list(request), auto_unbox = TRUE))
+    request <- as.list(request)
+
+    flog.info('Data received for scoring: %s', toJSON(request, auto_unbox = TRUE))
 
     ## try to score
-    request <- as.list(request)
-    class   <- tryCatch(predict(fit, newdata = request, type = 'class'),
-                        error = function(e) e)
+    response <- tryCatch({
 
-    ## and fail on missing values
-    for (v in paste(rep(c('sepal', 'petal'), 2), c('length', 'width'), sep = '_')) {
-        if (request[[v]] <= 0) {
-            class <- structure(list(message = paste('Negative', v, 'provided')), class = 'error')
-        }
-    }
+          for (v in attr(terms(fit), "term.labels")) {
+              if (request[[v]] > 0) next else {
+                  stop('Negative ', v, ' provided')
+              }
+          }
 
-    ## return error code/message on failure
-    if (inherits(class, 'error')) {
-        flog.error(class$message)
-        return(newResponse(status = new(iris.Status, code = 1, message = class$message)))
-    }
+          scores <- predict(fit, newdata = request)
+          i <- which.max(scores)
+          cls <- attr(fit, "ylevels")[i]
+          p <- scores[, i]
 
-    ## return score otherwise
-    class <- as.character(class)
-    p     <- predict(fit, newdata = request)[, class]
+          flog.info('Predicted class: %s (p=%5.4f)', cls, p)
+          newResponse(Species = cls, Probability = p)
+      },
+      error = function(e) {
+          newResponse(Status = new(iris.Status, code = 1, message = e$message))
+      })
 
-    flog.info('Predicted class: %s (p=%s)', class, p)
-    newResponse(species = class, probability = p)
+    return(response)
+
 
 }
 


### PR DESCRIPTION
* Only call predict once
* Read variable names / levels out of `fit` object
* Unify error handling

Please merge to your PR if this seems reasonable, then I will squash merge it. Thanks much!